### PR TITLE
fix: Pantallas de Login/Signup no rebotan en iphone

### DIFF
--- a/Apps/Screens/LoginScreen/index.jsx
+++ b/Apps/Screens/LoginScreen/index.jsx
@@ -84,6 +84,7 @@ export default function LoginScreen() {
           <ScrollView
             contentContainerStyle={styles.scrollContainer}
             keyboardShouldPersistTaps="handled"
+            bounces={false}
           >
             <View style={styles.main}>
               <Image source={icon} style={styles.icon} />


### PR DESCRIPTION
Issue: En Apple las pantallas rebotan al dar scroll. Hay que agregar el atributo "bounce" en todos los ScrollView.

Fuente:
https://stackoverflow.com/questions/43979916/disable-elastic-scrolling-inside-a-listview-react-native