### PR TITLE
fix: Teclado no funcionaba correctamente en ios

### DIFF
--- a/Apps/Screens/LoginScreen/index.jsx
+++ b/Apps/Screens/LoginScreen/index.jsx
@@ -82,7 +82,7 @@ export default function LoginScreen() {
         <KeyboardAvoidingView
           style={styles.container}
           behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={Platform.OS === "ios" ? 60 : 0}
+          keyboardVerticalOffset={0}
         >
           <ScrollView
             contentContainerStyle={styles.scrollContainer}


### PR DESCRIPTION
El teclado dejaba un espacio en blanco en ios.

Fuente: https://github.com/facebook/react-native/issues/29614